### PR TITLE
Fix requirements

### DIFF
--- a/classification/README.md
+++ b/classification/README.md
@@ -5,9 +5,13 @@ Python 3.8 is strongly recommended.
 PyTorch version `1.11` is strongly recommended.
 For ease of use, you can just set up a new environment and run the following:
 ```shell
-pip3 install -r requirements.txt
+pip3 install -r requirements-base.txt # Installs torch
+pip3 install -r requirements.txt # Installs NATTEN, timm, and fvcore
 ```
-This will install the recommended torch and torchvision, our CUDA extension, and all other dependencies.
+This will install the recommended torch and torchvision, 
+our PyTorch extension ([NATTEN](https://github.com/SHI-Labs/NATTEN)), 
+timm, 
+and all other dependencies.
 
 Our models are based on PyTorch, and was trained on ImageNet-1k classification using the `timm` package. 
 Additionally, they depend on our extension, [NATTEN](https://github.com/SHI-Labs/NATTEN), which you can install 
@@ -17,7 +21,9 @@ The following are the recommended versions of these libraries and are strongly e
 ```shell
 torch==1.11.0+cu113
 torchvision==0.12.0+cu113
-natten==0.14.1 # -f http://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
+
+natten==0.14.2+torch111cu113 # Wheels: http://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
+
 timm==0.5.0
 fvcore==0.1.5.post20220305
 pyyaml==6.0

--- a/classification/requirements-base.txt
+++ b/classification/requirements-base.txt
@@ -1,0 +1,4 @@
+-f https://download.pytorch.org/whl/cu113/torch_stable.html
+torch==1.11.0+cu113
+-f https://download.pytorch.org/whl/cu113/torch_stable.html
+torchvision==0.12.0+cu113

--- a/classification/requirements.txt
+++ b/classification/requirements.txt
@@ -1,7 +1,3 @@
--f https://download.pytorch.org/whl/cu113/torch_stable.html
-torch==1.11.0+cu113
--f https://download.pytorch.org/whl/cu113/torch_stable.html
-torchvision==0.12.0+cu113
 -f https://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
 natten
 git+https://github.com/rwightman/pytorch-image-models.git@9d6aad44f8fd32e89e5cca503efe3ada5071cc2a

--- a/detection/README.md
+++ b/detection/README.md
@@ -5,9 +5,13 @@ Python 3.8 is strongly recommended.
 PyTorch version `1.11` is strongly recommended.
 For ease of use, you can just set up a new environment and run the following:
 ```shell
-pip3 install -r requirements.txt
+pip3 install -r requirements-base.txt # Installs torch
+pip3 install -r requirements.txt # Installs NATTEN, MMCV, MMDET, and fvcore
 ```
-This will install the recommended torch and torchvision, our CUDA extension, and all other dependencies.
+This will install the recommended torch and torchvision, 
+our PyTorch extension ([NATTEN](https://github.com/SHI-Labs/NATTEN)), 
+MMCV, 
+and all other dependencies.
 
 Similar to and because of [classification](../classification/README.md), object detection also depends on `timm`, 
 and `fvcore`. Object detection experiments were conducted with [mmdetection](https://github.com/open-mmlab/mmdetection).
@@ -17,12 +21,14 @@ The following are the recommended versions of these libraries and are strongly e
 ```shell
 torch==1.11.0+cu113
 torchvision==0.12.0+cu113
-natten==0.14.1 # -f http://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
+
+mmcv-full==1.4.8 # Wheels: https://download.openmmlab.com/mmcv/dist/cu113/torch1.11.0/index.html
+
+natten==0.14.2+torch111cu113 # Wheels: http://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
+
+mmdet==2.19.0
 timm==0.5.0
 fvcore==0.1.5.post20220305
-
-mmcv-full==1.4.8
-mmdet==2.19.0
 ```
 
 ## Models

--- a/detection/requirements-base.txt
+++ b/detection/requirements-base.txt
@@ -1,0 +1,4 @@
+-f https://download.pytorch.org/whl/cu113/torch_stable.html
+torch==1.11.0+cu113
+-f https://download.pytorch.org/whl/cu113/torch_stable.html
+torchvision==0.12.0+cu113

--- a/detection/requirements.txt
+++ b/detection/requirements.txt
@@ -1,7 +1,3 @@
--f https://download.pytorch.org/whl/cu113/torch_stable.html
-torch==1.11.0+cu113
--f https://download.pytorch.org/whl/cu113/torch_stable.html
-torchvision==0.12.0+cu113
 -f https://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
 natten
 -f https://download.openmmlab.com/mmcv/dist/cu113/torch1.11.0/index.html

--- a/segmentation/README.md
+++ b/segmentation/README.md
@@ -5,9 +5,13 @@ Python 3.8 is strongly recommended.
 PyTorch version `1.11` is strongly recommended.
 For ease of use, you can just set up a new environment and run the following:
 ```shell
-pip3 install -r requirements.txt
+pip3 install -r requirements-base.txt # Installs torch
+pip3 install -r requirements.txt # Installs NATTEN, MMCV, MMSEG, and fvcore
 ```
-This will install the recommended torch and torchvision, our CUDA extension, and all other dependencies.
+This will install the recommended torch and torchvision, 
+our PyTorch extension ([NATTEN](https://github.com/SHI-Labs/NATTEN)), 
+MMCV, 
+and all other dependencies.
 
 Similar to and because of [classification](../classification/README.md), semantic segmentation also depends on `timm`, 
 and `fvcore`. Semantic Segmentation experiments were conducted with [mmsegmentation](https://github.com/open-mmlab/mmsegmentation/).
@@ -17,12 +21,14 @@ The following are the recommended versions of these libraries and are strongly e
 ```shell
 torch==1.11.0+cu113
 torchvision==0.12.0+cu113
-natten==0.14.1 # -f http://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
+
+mmcv-full==1.4.8 # Wheels: https://download.openmmlab.com/mmcv/dist/cu113/torch1.11.0/index.html
+
+natten==0.14.2+torch111cu113 # Wheels: http://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
+
+mmsegmentation==0.20.2
 timm==0.5.0
 fvcore==0.1.5.post20220305
-
-mmcv-full==1.4.8
-mmsegmentation==0.20.2
 ```
 
 ## Models

--- a/segmentation/requirements-base.txt
+++ b/segmentation/requirements-base.txt
@@ -1,0 +1,4 @@
+-f https://download.pytorch.org/whl/cu113/torch_stable.html
+torch==1.11.0+cu113
+-f https://download.pytorch.org/whl/cu113/torch_stable.html
+torchvision==0.12.0+cu113

--- a/segmentation/requirements.txt
+++ b/segmentation/requirements.txt
@@ -1,7 +1,3 @@
--f https://download.pytorch.org/whl/cu113/torch_stable.html
-torch==1.11.0+cu113
--f https://download.pytorch.org/whl/cu113/torch_stable.html
-torchvision==0.12.0+cu113
 -f https://www.shi-labs.com/natten/wheels/cu113/torch1.11/index.html
 natten
 -f https://download.openmmlab.com/mmcv/dist/cu113/torch1.11.0/index.html


### PR DESCRIPTION
This modifies README files in `classification/`, `detection/` and `segmentation/`, and splits `requirements.txt` in each into two: `requirements-base.txt` and `requirements.txt`.

Reason: NATTEN requires PyTorch to be installed first, even when it's being set up with wheels, since it checks the torch version to ensure it matches up with the minimum requirements. `pip install -r $FILE` prepares packages and installs all of them if and only if all are set up successfully. This would fail to work for anyone that doesn't have torch preinstalled.

README files are modified to clarify this, upgrade to use the latest NATTEN, and to include the MMCV wheel URL.